### PR TITLE
MSM8916: Overlock Extreme

### DIFF
--- a/arch/arm/boot/dts/samsung/msm8916/msm8916-gpu.dtsi
+++ b/arch/arm/boot/dts/samsung/msm8916/msm8916-gpu.dtsi
@@ -23,7 +23,7 @@
 
 		qcom,chipid = <0x03000600>;
 
-		qcom,initial-pwrlevel = <1>;
+		qcom,initial-pwrlevel = <5>;
 
 		/* Idle Timeout = HZ/12 */
 		qcom,idle-timeout = <8>;
@@ -50,9 +50,9 @@
 		qcom,msm-bus,num-paths = <1>;
 		qcom,msm-bus,vectors-KBps =
 			<26 512 0 0>,
-			<26 512 400000 1600000>,
-			<26 512 800000 3200000>,
-			<26 512 1066000 4264000>;
+			<26 512 0 5600000>,
+		        <26 512 0 5984000>,
+		        <26 512 0 6368000>;
 
 		/* GDSC oxili regulators */
 		vdd-supply = <&gdsc_oxili_gx>;
@@ -80,13 +80,13 @@
 
 			qcom,gpu-pwrlevel@0 {
 				reg = <0>;
-				qcom,gpu-freq = <400000000>;
+				qcom,gpu-freq = <1000000000>;
 				qcom,bus-freq = <3>;
 			};
 
 			qcom,gpu-pwrlevel@1 {
 				reg = <1>;
-				qcom,gpu-freq = <310000000>;
+				qcom,gpu-freq = <465000000>;
 				qcom,bus-freq = <2>;
 			};
 
@@ -105,4 +105,3 @@
 
 	};
 };
-

--- a/arch/arm/boot/dts/samsung/msm8916/msm8916-regulator.dtsi
+++ b/arch/arm/boot/dts/samsung/msm8916/msm8916-regulator.dtsi
@@ -50,10 +50,10 @@
 		regulator-name = "apc_corner";
 		qcom,cpr-fuse-corners = <3>;
 		regulator-min-microvolt = <1>;
-		regulator-max-microvolt = <7>;
+		regulator-max-microvolt = <12>;
 
 		qcom,cpr-voltage-ceiling = <1050000 1150000 1350000>;
-		qcom,cpr-voltage-floor = <1050000 1150000 1350000>;
+		qcom,cpr-voltage-floor = <1050000 1050000 1162500>;
 		vdd-apc-supply = <&pm8916_s2>;
 
 		qcom,vdd-mx-corner-map = <4 5 7>;
@@ -87,18 +87,23 @@
 					<27 0 6 0>;
 		qcom,cpr-init-voltage-ref = <1050000 1150000 1350000>;
 		qcom,cpr-init-voltage-step = <10000>;
-		qcom,cpr-corner-map = <1 1 2 2 3 3 3>;
+		qcom,cpr-corner-map = <1 1 1 2 2 2 3 3 3 3 3 3>;
 		qcom,cpr-corner-frequency-map =
-					<1 200000000>,
-					<2 400000000>,
-					<3 533330000>,
-					<4 800000000>,
-					<5 998400000>,
-					<6 1094400000>,
-					<7 1190400000>;
+					<1 400000000>,
+					<2 533330000>,
+					<3 800000000>,
+					<4 998400000>,
+					<5 1094400000>,
+					<6 1190400000>,
+					<7 1248000000>,
+					<8 1363200000>,
+					<9 1401600000>,
+					<10 1497600000>,
+					<11 1632000000>,
+					<12 1881600000>;
 		qcom,speed-bin-fuse-sel = <1 34 3 0>;
 		qcom,cpr-speed-bin-max-corners =
-					<0 0 2 4 7>;
+					<0 0 2 4 12>;
 		qcom,cpr-quot-adjust-scaling-factor-max = <650>;
 		qcom,cpr-enable;
 	};

--- a/arch/arm/boot/dts/samsung/msm8916/msm8916.dtsi
+++ b/arch/arm/boot/dts/samsung/msm8916/msm8916.dtsi
@@ -25,7 +25,7 @@
 	interrupt-parent = <&intc>;
 
 	chosen {
-		bootargs = "sched_enable_hmp=1";
+		bootargs = "boot_cpus=0,1,2,3 sched_enable_hmp=1";
 	};
 
 	aliases {
@@ -369,13 +369,18 @@
 		#clock-cells = <1>;
 		qcom,speed0-bin-v0 =
 			<          0 0>,
-			<  200000000 1>,
-			<  400000000 2>,
-			<  533333000 3>,
-			<  800000000 4>,
-			<  998400000 5>,
-			< 1094400000 6>,
-			< 1190400000 7>;
+			<  400000000 1>,
+			<  533333000 2>,
+			<  800000000 3>,
+			<  998400000 4>,
+			< 1094400000 5>,
+			< 1190400000 6>,
+			< 1363200000 7>,
+			< 1248000000 8>,
+			< 1401600000 9>,
+			< 1497600000 10>,
+			< 1632000000 11>,
+			< 1881600000 12>;
 	};
 
 	cpubw: qcom,cpubw@0 {
@@ -385,10 +390,11 @@
 		qcom,src-dst-ports = <1 512>;
 		qcom,active-only;
 		qcom,bw-tbl =
-			<  762 /* 100 MHz */>,
+			<  763 /* 100 MHz */>,
 			< 1525 /* 200 MHz */>,
-			< 3051 /* 400 MHz */>,
-			< 4066 /* 533 MHz */>;
+			< 3052 /* 400 MHz */>,
+			< 4066 /* 533 MHz */>,
+			< 4580 /* 600 MHz */>;
 		qcom,ab-percent = < 30 >;
 	};
 
@@ -403,10 +409,10 @@
 			target-dev = <&cpubw>;
 			cpu-to-dev-map =
 				 <  400000  762>,
-				 <  800000  1525>,
+				 <  533330  1525>,
 				 <  998400  3051>,
-				 < 1094400  3051>,
-				 < 1190400  4066>;
+				 < 1190400  4066>,
+				 < 1881600  4580>;
 		};
 	};
 
@@ -420,13 +426,18 @@
 		clock-names = "cpu0_clk", "cpu1_clk",
 				"cpu2_clk", "cpu3_clk";
 		qcom,cpufreq-table =
-			 <  200000 >,
 			 <  400000 >,
 			 <  533330 >,
 			 <  800000 >,
 			 <  998400 >,
 			 < 1094400 >,
-			 < 1190400 >;
+			 < 1190400 >,
+			 < 1248000 >,
+			 < 1363200 >,
+			 < 1401600 >,
+			 < 1497600 >,
+			 < 1632000 >,
+			 < 1881600 >;
 	};
 
 	qcom,sps {
@@ -681,7 +692,7 @@
 			 <&clock_gcc clk_gcc_sdcc1_apps_clk>;
 		clock-names = "iface_clk", "core_clk";
 
-		qcom,clk-rates = <400000 25000000 50000000 100000000 177770000>;
+		qcom,clk-rates = <400000 25000000 50000000 100000000 200000000>;
 		qcom,bus-speed-mode = "HS200_1p8v", "DDR_1p8v";
 
 		status = "disabled";
@@ -1476,7 +1487,7 @@
 		clocks = <&clock_gcc clk_gcc_blsp1_ahb_clk>,
 			 <&clock_gcc clk_gcc_blsp1_qup2_i2c_apps_clk>;
 		clock-names = "iface_clk", "core_clk";
-		qcom,clk-freq-out = <100000>;
+		qcom,clk-freq-out = <400000>;
 		qcom,clk-freq-in  = <19200000>;
 		pinctrl-names = "i2c_active", "i2c_sleep";
 		pinctrl-0 = <&i2c_0_active>;
@@ -1497,7 +1508,7 @@
 		      <0x7884000 0x23000>;
 		interrupt-names = "qup_irq", "bam_irq";
 		interrupts = <0 95 0>, <0 238 0>;
-		qcom,clk-freq-out = <100000>;
+		qcom,clk-freq-out = <400000>;
 		qcom,clk-freq-in  = <19200000>;
 		clock-names = "iface_clk", "core_clk";
 		clocks = <&clock_gcc clk_gcc_blsp1_ahb_clk>,
@@ -2250,4 +2261,3 @@
 		/* If you need to add new key type, add it this position */
 	};
 };
-

--- a/drivers/clk/qcom/clock-gcc-8916.c
+++ b/drivers/clk/qcom/clock-gcc-8916.c
@@ -348,6 +348,9 @@ static struct pll_freq_tbl apcs_pll_freq[] = {
 	F_APCS_PLL(1248000000, 65, 0x0, 0x1, 0x0, 0x0, 0x0),
 	F_APCS_PLL(1363200000, 71, 0x0, 0x1, 0x0, 0x0, 0x0),
 	F_APCS_PLL(1401600000, 73, 0x0, 0x1, 0x0, 0x0, 0x0),
+	F_APCS_PLL(1497600000, 78, 0x0, 0x1, 0x0, 0x0, 0x0),
+	F_APCS_PLL(1632000000, 85, 0x0, 0x1, 0x0, 0x0, 0x0),
+	F_APCS_PLL(1881600000, 99, 0x0, 0x1, 0x0, 0x0, 0x0),
 	PLL_F_END
 };
 
@@ -553,6 +556,7 @@ static struct clk_freq_tbl ftbl_gcc_camss_vfe0_clk[] = {
 	F( 320000000,	   gpll0, 2.5,	  0,	0),
 	F( 400000000,	   gpll0,   2,	  0,	0),
 	F( 465000000,	   gpll2,   2,	  0,	0),
+	F( 1000000000,	   gpll2,   2,	  0,	0),
 	F_END
 };
 
@@ -566,12 +570,12 @@ static struct rcg_clk vfe0_clk_src = {
 		.dbg_name = "vfe0_clk_src",
 		.ops = &clk_ops_rcg,
 		VDD_DIG_FMAX_MAP3(LOW, 160000000, NOMINAL, 320000000, HIGH,
-			465000000),
+			1000000000),
 		CLK_INIT(vfe0_clk_src.c),
 	},
 };
 
-static struct clk_freq_tbl ftbl_gcc_oxili_gfx3d_465_clk[] = {
+static struct clk_freq_tbl ftbl_gcc_oxili_gfx3d_1000_clk[] = {
 	F(  19200000,	      xo,   1,	  0,	0),
 	F(  50000000,  gpll0_aux,  16,	  0,	0),
 	F(  80000000,  gpll0_aux,  10,	  0,	0),
@@ -581,9 +585,10 @@ static struct clk_freq_tbl ftbl_gcc_oxili_gfx3d_465_clk[] = {
 	F( 200000000,  gpll0_aux,   4,	  0,	0),
 	F( 266670000,  gpll0_aux,   3,	  0,	0),
 	F( 294912000,	   gpll1,   3,	  0,	0),
-	F( 310000000,	   gpll2,   3,	  0,	0),
+	F( 320000000,	   gpll2,   3,	  0,	0),
 	F( 400000000,  gpll0_aux,   2,	  0,	0),
 	F( 465000000,      gpll2,   2,	  0,	0),
+	F( 1000000000,	   gpll0,   2,	  0,	0),
 	F_END
 };
 
@@ -597,8 +602,10 @@ static struct clk_freq_tbl ftbl_gcc_oxili_gfx3d_clk[] = {
 	F( 200000000,  gpll0_aux,   4,	  0,	0),
 	F( 266670000,  gpll0_aux,   3,	  0,	0),
 	F( 294912000,	   gpll1,   3,	  0,	0),
-	F( 310000000,	   gpll2,   3,	  0,	0),
+	F( 320000000,	   gpll2,   3,	  0,	0),
 	F( 400000000,  gpll0_aux,   2,	  0,	0),
+	F( 465000000,      gpll2,   2,	  0,	0),
+	F( 1000000000,	   gpll2,   2,	  0,	0),
 	F_END
 };
 
@@ -611,8 +618,8 @@ static struct rcg_clk gfx3d_clk_src = {
 	.c = {
 		.dbg_name = "gfx3d_clk_src",
 		.ops = &clk_ops_rcg,
-		VDD_DIG_FMAX_MAP3(LOW, 200000000, NOMINAL, 310000000, HIGH,
-			400000000),
+		VDD_DIG_FMAX_MAP3(LOW, 200000000, NOMINAL, 465000000, HIGH,
+			1000000000),
 		CLK_INIT(gfx3d_clk_src.c),
 	},
 };
@@ -996,8 +1003,10 @@ static struct rcg_clk csi1phytimer_clk_src = {
 
 static struct clk_freq_tbl ftbl_gcc_camss_cpp_clk[] = {
 	F( 160000000,	   gpll0,   5,	  0,	0),
+	F( 200000000,	   gpll0,   4,	  0,	0),
 	F( 320000000,	   gpll0, 2.5,	  0,	0),
 	F( 465000000,	   gpll2,   2,	  0,	0),
+	F( 1000000000,	   gpll2,   2,	  0,	0),
 	F_END
 };
 
@@ -1011,7 +1020,7 @@ static struct rcg_clk cpp_clk_src = {
 		.dbg_name = "cpp_clk_src",
 		.ops = &clk_ops_rcg,
 		VDD_DIG_FMAX_MAP3(LOW, 160000000, NOMINAL, 320000000, HIGH,
-			465000000),
+			1000000000),
 		CLK_INIT(cpp_clk_src.c),
 	},
 };
@@ -1192,6 +1201,7 @@ static struct clk_freq_tbl ftbl_gcc_sdcc1_apps_clk[] = {
 	F(  50000000,	   gpll0,  16,	  0,	0),
 	F( 100000000,	   gpll0,   8,	  0,	0),
 	F( 177770000,	   gpll0, 4.5,	  0,	0),
+	F( 200000000,	   gpll0,   4,	  0,	0),
 	F_END
 };
 
@@ -1216,7 +1226,7 @@ static struct clk_freq_tbl ftbl_gcc_sdcc2_apps_clk[] = {
 	F(  25000000,	   gpll0,  16,	  1,	2),
 	F(  50000000,	   gpll0,  16,	  0,	0),
 	F( 100000000,	   gpll0,   8,	  0,	0),
-	F( 177770000,	   gpll0,   4.5,	  0,	0),
+	F( 177770000,	   gpll0, 4.5,	  0,	0),
 	F( 200000000,	   gpll0,   4,	  0,	0),
 	F_END
 };
@@ -2797,8 +2807,8 @@ static void gcc_gfx3d_fmax(struct platform_device *pdev)
 	pr_info("%s, Version: %d, bin: %d\n", __func__, version,
 					bin);
 
-	gfx3d_clk_src.c.fmax[VDD_DIG_HIGH] = 465000000;
-	gfx3d_clk_src.freq_tbl = ftbl_gcc_oxili_gfx3d_465_clk;
+	gfx3d_clk_src.c.fmax[VDD_DIG_HIGH] = 1000000000;
+	gfx3d_clk_src.freq_tbl = ftbl_gcc_oxili_gfx3d_1000_clk;
 }
 
 static int msm_gcc_probe(struct platform_device *pdev)


### PR DESCRIPTION
CPU: Overclock to 1881MHz. Maxed out multiplier:×99 BCLK: 192MHz CPU Frequency: 192×99=1,81GHz
GPU: Gaming Performance, overclock up to 1GHz (1000MHz)
LPDDR3 533MHz: Overclock to 600MHz, Performance Enhancement, reduce delay or lag during gaming
i2c_0, i2c_1: usb, motherboard, etc communication bus/speed/bandwitch from STANDARD mode to FAST mode: 100->400MHz, only two frequency mode are allowed to set.
EMMC: Set max/ Overclock eMMC clock frequency to 200MHz
from current value of 177.77MHz. (Warning: Risk of data corruption)